### PR TITLE
Get rid of loading screen

### DIFF
--- a/design.css
+++ b/design.css
@@ -174,6 +174,7 @@ body[type*=server] .line:hover .time {
 
 /* Loading Screen */
 body div#loading_screen {
+    display:none;
     position:absolute;
     top: 50%;
     left: 50%;

--- a/scripts.js
+++ b/scripts.js
@@ -105,14 +105,3 @@ Textual.newMessagePostedToView = function (lineNum) {
     Sulaco.coalesceMessages(lineNum);
 };
 
-Textual.viewFinishedLoading = function () {
-    Textual.fadeInLoadingScreen(1.00, 0.95);
-
-    setTimeout(function () {
-        Textual.scrollToBottomOfView();
-    }, 300);
-};
-
-Textual.viewFinishedReload = function () {
-    Textual.viewFinishedLoading();
-};


### PR DESCRIPTION
In regards to #7. I don't really know how the loading screen stuff worked in Textual 4.x but it seems to have been removed in Textual 5, so this just removes it from the theme.

I'm open to suggestions on fixing it as opposed to just removing it, but this was the quickest way to get it functional on my machine and thought I'd throw it up for anybody else who might want it.
